### PR TITLE
fix: remove become option at homebrew tasks

### DIFF
--- a/tests/roles/git/tasks/Darwin.yml
+++ b/tests/roles/git/tasks/Darwin.yml
@@ -1,4 +1,3 @@
 - name: Install git
   homebrew:
     name: git
-  become: "{{ nonroot }}"


### PR DESCRIPTION
```
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
```